### PR TITLE
add `exitAfterExecute` to avoid `process.exit()` in programmatically execute API.

### DIFF
--- a/source/main.ts
+++ b/source/main.ts
@@ -8,7 +8,8 @@ export default async function esrun(
 	inputFile: string,
 	args: string[] = [],
 	watch: boolean | string[] = false,
-	inspect = false
+	inspect = false,
+	exitAfterExecute = true
 ) {
 	if (watch && inspect) {
 		console.warn(
@@ -16,5 +17,5 @@ export default async function esrun(
 		)
 		watch = false
 	}
-	return new (watch ? Watcher : Runner)(inputFile, args, watch, inspect).run()
+	return new (watch ? Watcher : Runner)(inputFile, args, watch, inspect, exitAfterExecute).run()
 }

--- a/source/runners/Runner.ts
+++ b/source/runners/Runner.ts
@@ -20,7 +20,8 @@ export default class Runner {
 		input: string,
 		public args: string[] = [],
 		protected watch: boolean | string[] = false,
-		protected inspect: boolean = false
+		protected inspect: boolean = false,
+		protected exitAfterExecuted: boolean = true,
 	) {
 		this.input = findInputFile(input)
 	}
@@ -32,7 +33,8 @@ export default class Runner {
 	async run() {
 		try {
 			await this.build()
-			process.exit(await this.execute())
+			const ret = await this.execute()
+			if (this.exitAfterExecuted) process.exit(ret)
 		} catch (error) {
 			console.error(error)
 			process.exit(1)


### PR DESCRIPTION
add exitAfterExecute arg.