### PR TITLE
Added option to preserve console output in watch mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ In case of troubleshooting, read the [node documentation](https://nodejs.org/en/
 
 > Inspect and watch mode are alas not compatible yet.
 
+### Preserve Console Output
+
+If you don't want the console cleared in watch mode for each console update, use the following flag:
+
+```shell
+esrun --watch foo.ts --preserveConsole
+```
 
 ### Importing a CJS module
 

--- a/source/bin.ts
+++ b/source/bin.ts
@@ -9,11 +9,14 @@ const argumentOptions: Record<string, ExecutionMode> = {
 	"-w": "watch",
 	"--inspect": "inspect",
 	"-i": "inspect",
+  	"-p": "preserveConsole",
+  	"--preserveConsole": "preserveConsole",	
 }
 
 const options: Record<ExecutionMode, boolean | string[]> = {
 	watch: false,
 	inspect: false,
+  	preserveConsole: false,
 }
 
 let argsOffset = 2
@@ -35,4 +38,5 @@ esrun(argv[argsOffset], {
 	args: argv.slice(argsOffset + 1),
 	watch: options.watch,
 	inspect: !!options.inspect,
+  	preserveConsole: !!options.preserveConsole,
 })

--- a/source/runners/Runner.ts
+++ b/source/runners/Runner.ts
@@ -20,6 +20,7 @@ export default class Runner {
 
 	protected watch: boolean | string[]
 	protected inspect: boolean
+	protected preserveConsole: boolean
 	protected interProcessCommunication
 	protected makeAllPackagesExternal
 	protected exitAfterExecution
@@ -38,6 +39,7 @@ export default class Runner {
 		this.args = options?.args ?? []
 		this.watch = options?.watch ?? false
 		this.inspect = options?.inspect ?? false
+		this.preserveConsole = options?.preserveConsole ?? false
 		this.interProcessCommunication = options?.interProcessCommunication ?? false
 		this.makeAllPackagesExternal = options?.makeAllPackagesExternal ?? true
 		this.exitAfterExecution = options?.exitAfterExecution ?? true

--- a/source/runners/Watcher.ts
+++ b/source/runners/Watcher.ts
@@ -21,13 +21,16 @@ export default class Watcher extends Runner {
 
 	constructor(input: string, options?: Options) {
 		super(input, options)
+		this.preserveConsole = options?.preserveConsole ?? false
 		this.watch =
 			options?.watch instanceof Array ? options.watch.map(glob => path.resolve(glob)) : []
 	}
 
 	async run() {
 		try {
-			console.clear()
+			if(!this.preserveConsole){
+				console.clear()
+			}
 			await this.build()
 			this.execute()
 			this.watcher = watch([...this.dependencies, "package.json", ...this.watch])
@@ -73,7 +76,9 @@ export default class Watcher extends Runner {
 	}
 
 	async rebuild() {
-		console.clear()
+		if(!this.preserveConsole){
+			console.clear()
+		}
 		this.dependencies.length = 0
 		if (this.buildOutput) {
 			try {

--- a/source/types/ExecutionMode.ts
+++ b/source/types/ExecutionMode.ts
@@ -1,1 +1,1 @@
-export type ExecutionMode = "watch" | "inspect"
+export type ExecutionMode = "watch" | "inspect" | "preserveConsole"

--- a/source/types/Options.ts
+++ b/source/types/Options.ts
@@ -2,6 +2,7 @@ export type Options = {
 	args?: string[]
 	watch?: boolean | string[]
 	inspect?: boolean
+	preserveConsole?: boolean
 	interProcessCommunication?: boolean
 	makeAllPackagesExternal?: boolean
 	exitAfterExecution?: boolean


### PR DESCRIPTION
This is handy when you have other things running at the same time in the console. e.g. If you are using the [concurrently](https://github.com/open-cli-tools/concurrently) program, clearing the console would remove the previous output of other programs.