### PR TITLE
replace cuid with @paralleldrive/cuid2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
 	"homepage": "https://github.com/digital-loukoum/esrun#readme",
 	"dependencies": {
 		"@digitak/grubber": "^3.1.4",
+		"@paralleldrive/cuid2": "^2.2.0",
 		"chokidar": "^3.5.1",
-		"cuid": "^2.1.8",
 		"esbuild": "^0.17.4"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,9 +3,9 @@ lockfileVersion: 5.4
 specifiers:
   '@digitak/bunker': ^3.2.1
   '@digitak/grubber': ^3.1.4
+  '@paralleldrive/cuid2': ^2.2.0
   '@types/node': ^14.14.20
   chokidar: ^3.5.1
-  cuid: ^2.1.8
   cute-print: ^1.0.4
   esbuild: ^0.17.4
   fartest: ^2.1.6
@@ -15,8 +15,8 @@ specifiers:
 
 dependencies:
   '@digitak/grubber': 3.1.4
+  '@paralleldrive/cuid2': 2.2.0
   chokidar: 3.5.3
-  cuid: 2.1.8
   esbuild: 0.17.4
 
 devDependencies:
@@ -241,6 +241,16 @@ packages:
     dev: false
     optional: true
 
+  /@noble/hashes/1.2.0:
+    resolution: {integrity: sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==}
+    dev: false
+
+  /@paralleldrive/cuid2/2.2.0:
+    resolution: {integrity: sha512-CVQDpPIUHrUGGLdrMGz1NmqZvqmsB2j2rCIQEu1EvxWjlFh4fhvEGmgR409cY20/67/WlJsggenq0no3p3kYsw==}
+    dependencies:
+      '@noble/hashes': 1.2.0
+    dev: false
+
   /@polka/url/0.5.0:
     resolution: {integrity: sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw==}
     dev: true
@@ -309,10 +319,6 @@ packages:
   /color-name/1.1.3:
     resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
     dev: true
-
-  /cuid/2.1.8:
-    resolution: {integrity: sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==}
-    dev: false
 
   /cute-print/1.0.4:
     resolution: {integrity: sha512-ow+LrLYY2Voiq6phfz/RpFICmvAQHJHP/uvZQFcQc6VhtD8gyAKtK8MbO911nlwM5A5Ys5Mdz6HnxAodNbwtlg==}

--- a/source/runners/Runner.ts
+++ b/source/runners/Runner.ts
@@ -6,7 +6,7 @@ import { Options } from "../types/Options.js";
 import { fileConstantsPlugin } from "../plugins/fileConstants.js";
 import path, { posix } from "path";
 import { SendCodeMode } from "../types/SendCodeMode.js";
-import cuid from "cuid";
+import {createId} from "@paralleldrive/cuid2";
 import { unlinkSync, writeFileSync } from "fs";
 import { findBinDirectory } from "../tools/findBinDirectory.js";
 import { importRequire } from "../tools/importRequire.js";
@@ -166,7 +166,7 @@ export default class Runner {
 			// we create a temporary file that we will execute
 			const binDirectory = findBinDirectory();
 			this.outputFile = path.normalize(
-				posix.join(binDirectory, `esrun-${cuid()}.tmp.mjs`),
+				posix.join(binDirectory, `esrun-${createId()}.tmp.mjs`),
 			);
 			if (binDirectory && binDirectory !== ".") {
 				code = code


### PR DESCRIPTION
#### description
- [paralleldrive/cuid](https://github.com/paralleldrive/cuid/commit/e15b0679a2f3d9444021e584f8cfffbc7ee54ce8) added a depreciation notice (31/Dec/22)

```sh
npm install -g @digitak/esrun
# npm WARN deprecated cuid@2.1.8: Cuid and other k-sortable and non-cryptographic ids (Ulid, ObjectId, KSUID, all UUIDs) are all insecure. Use @paralleldrive/cuid2 instead.

# added 20 packages in 857ms

npm info @digitak/esrun | grep -o dependencies -A5
# dependencies
# @digitak/grubber: ^3.1.4
# chokidar: ^3.5.1
# cuid: ^2.1.8
# esbuild: ^0.17.4
```

- replacement
  - [paralleldrive/cuid2](https://github.com/paralleldrive/cuid2)


