### PR TITLE
security: update esbuild to address CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	"dependencies": {
 		"@digitak/grubber": "^3.1.4",
 		"chokidar": "^3.5.1",
-		"esbuild": "^0.17.4"
+		"esbuild": "^0.24.2"
 	},
 	"devDependencies": {
 		"@digitak/bunker": "^3.2.1",


### PR DESCRIPTION
Updates esbuild from ^0.17.4 to ^0.24.2 to address critical Go stdlib vulnerabilities.

This update resolves the following CVEs:
- CVE-2023-24531: Command injection in go env
- CVE-2023-29405: Arbitrary code execution via linker flags
- CVE-2024-24790: IPv4-mapped IPv6 address handling
- CVE-2023-29402: Unexpected code generation with cgo
- CVE-2023-29404: Arbitrary code execution via LDFLAGS
- CVE-2025-22871: HTTP request smuggling via bare LF

Resolves #49

Generated with [Claude Code](https://claude.ai/code)